### PR TITLE
Fix for invisible enemies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 **/*.rs.bk
+/log
+*.log

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -41,7 +41,6 @@ pub struct Character {
     luck: i32,
     xp: i32,
     tile: Tile,
-    visible: bool,
 }
 
 pub trait Enemy {
@@ -114,11 +113,14 @@ impl Entity for Character {
     }
 
     fn visibility(&mut self, visible: bool) {
-        self.visible = visible;
+        if visible != self.is_visible() {
+            self.dirty = true;
+        }
+        self.tile.visibility(visible)
     }
 
     fn is_visible(&self) -> bool {
-        self.visible
+        self.tile.is_visible()
     }
 }
 
@@ -146,7 +148,6 @@ impl Enemy for Character {
             previous_location: location,
             tile: Tile::from(TileType::Character(tile_str)),
             dirty: false,
-            visible: false,
         }
     }
 
@@ -181,7 +182,6 @@ impl Player for Character {
                 true, // player is visible by default
             ),
             dirty: false,
-            visible: true,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,6 @@ fn main() {
     let mut reader = input.read_sync();
 
     loop {
-        state.render_player();
         state.render_level();
         state.render_entities();
         state.render_player();

--- a/src/world.rs
+++ b/src/world.rs
@@ -310,7 +310,11 @@ impl Level {
             corridor.tile(&mut grid)?;
         }
 
-        grid.set_tile(self.entrance.0, self.entrance.1, Tile::from(TileType::StairsUp));
+        grid.set_tile(
+            self.entrance.0,
+            self.entrance.1,
+            Tile::from(TileType::StairsUp),
+        );
         grid.set_tile(self.exit.0, self.exit.1, Tile::from(TileType::StairsDown));
 
         Ok(grid)
@@ -426,20 +430,19 @@ impl Generatable for Level {
             let room = &self.rooms[rng.gen_range(0, self.rooms.len() - 1)];
 
             // Create the enemy
-            self.entities.push(Box::<Character>::new(
-                Enemy::new(
-                    String::from("snake"),
-                    2 * self.depth as i32,
-                    (2.0 * self.depth as f32 * 0.6).round() as i32,
-                    (20.0 * self.depth as f32 * 0.2).max(80.0).round() as i32,
-                    0,
-                    (
-                        room.start.0 + rng.gen_range(0, room.width),
-                        room.start.1 + rng.gen_range(0, room.height),
-                    ),
-                    "s",
-                )
-            ));
+            let enemy_coords = (
+                room.start.0 + rng.gen_range(0, room.width - 1) + 1,
+                room.start.1 + rng.gen_range(0, room.height - 1) + 1,
+            );
+            self.entities.push(Box::<Character>::new(Enemy::new(
+                String::from("snake"),
+                2 * self.depth as i32,
+                (2.0 * self.depth as f32 * 0.6).round() as i32,
+                (20.0 * self.depth as f32 * 0.2).max(80.0).round() as i32,
+                0,
+                enemy_coords,
+                "s",
+            )));
         }
     }
 }


### PR DESCRIPTION
- Don't double-count visibility
- Set enemies visibility with LOS
- Set dirty flag when enemies are revealed